### PR TITLE
Fixes MUSCLE on arm64 macOS devices and adds script to PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ dmypy.json
 *.aln
 *.treefile
 .DS_Store
+muscle

--- a/bridge
+++ b/bridge
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Get the current directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Activate the virtual environment
+# Check if the environment is named .venv
+if [[ -d $DIR/.venv/ ]]; then
+    source "$DIR/.venv/bin/activate"
+elif [[ -d $DIR/venv/ ]]; then
+    source $DIR/venv/bin/activate
+else
+    echo "No virtual environment found. Please run setup first."
+    exit 1
+fi
+
+# Grab any arguments
+args=$@
+
+# Run Bridge
+python "$DIR/bridge.py" $args

--- a/setup
+++ b/setup
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Check if virtualenv is installed
+if ! [ -x "$(command -v virtualenv)" ]; then
+    pip install virtualenv
+fi
+
 # Set up the environment
 if [ ! -d venv ]; then
     virtualenv venv
@@ -13,3 +18,19 @@ pip install -r requirements.txt
 
 # Run the initial setup
 python bridge.py --initial_setup
+
+# Make sure "bridge" is executable
+chmod +x bridge
+
+# Add "bridge" to the user's PATH based on their favorite shell
+# If .bashrc exists, add the line to it
+if [ -f ~/.bashrc ]; then
+    echo "export \"PATH=\$PATH:$(pwd)\"" >> ~/.bashrc
+fi
+
+# If .zshrc exists, add the line to it
+if [ -f ~/.zshrc ]; then
+    echo "export \"PATH=\$PATH:$(pwd)\"" >> ~/.zshrc
+fi
+
+


### PR DESCRIPTION
Older versions of Bridge had to rely on MUSCLE being installed via Homebrew for those on Apple Silicon macOS devices. This is because of some dependency in the MUSCLE binary available that only works on Intel-based macOS systems. This update grabs the source code for MUSCLE and builds it locally after making a change based on [previous discussion](https://github.com/rcedgar/muscle/issues/21) of this issue I'd found.

This update also changes the shell scripts provided. Now, setup uses the Python built-in method of creating a virtual environment to avoid premature dependency requirements and it also adds a new script, `bridge` to the user's PATH. This `bridge` script is meant to activate the user's virtual environment, and run the program with any provided arguments. This allows the program to be called from anywhere by virtue of it now being included on the PATH.